### PR TITLE
Fix typo in doc table of content.

### DIFF
--- a/docs/code-reference.rst
+++ b/docs/code-reference.rst
@@ -7,7 +7,7 @@ Client
 .. autoclass:: brickfront.client.Client
    :members:
 
-Game
+Build
 ----------
 
 .. autoclass:: brickfront.build.Build


### PR DESCRIPTION
Just a minor fix in the documentation.